### PR TITLE
Update 2020-07-31-yang20a.md

### DIFF
--- a/_posts/2020-07-31-yang20a.md
+++ b/_posts/2020-07-31-yang20a.md
@@ -28,12 +28,14 @@ order: 486
 cycles: false
 bibtex_author: Yang, Zhuoran and Xie, Yuchen and Wang, Zhaoran
 author:
-- given: Zhuoran
-  family: Yang
+- given: Jianqing 
+  family: Fan
+- given: Zhaoran 
+  family: Wang
 - given: Yuchen
   family: Xie
-- given: Zhaoran
-  family: Wang
+- given: Zhuoran
+  family: Yang
 date: 2020-07-31
 address: 
 publisher: PMLR


### PR DESCRIPTION
Correct the author list. Currently the author list on website ``http://proceedings.mlr.press/v120/yang20a.html'' does not match that on the PDF file.